### PR TITLE
Fixed wrong command in GIVE_ICON_SUCCESS

### DIFF
--- a/translation/lang_en.ini
+++ b/translation/lang_en.ini
@@ -26,7 +26,7 @@ GIVE_ROLE_FAILED_BLACKLIST = {} is in the blacklist and may not be given out!
 GIVE_ROLE_FAILED_EXISTS = {} already has the role {}!
 GIVE_ROLE_SUCCESS = {} has been given the role {}! You can equip your new role by doing `/roles`.
 ;Variable Order: User Mention, Role Mention
-GIVE_ICON_SUCCESS = {} has been given the icon {}! You can equip your new icon by doing `/icons`.
+GIVE_ICON_SUCCESS = {} has been given the icon {}! You can equip your new icon by doing `/roles`.
 
 REMOVE_ROLE_FAILED_EVERYONE = You can not remove @everyone from somebody!
 REMOVE_ROLE_SUCCESS = {} was removed from {}!


### PR DESCRIPTION
The GIVE_ICON_SUCCESS command tells people to do `/icons` to equip their icon, however the actual command to equip icons is `/roles`.
This PR just changes the sentence to say `/roles` instead of `/icons`.